### PR TITLE
Use Slick StateBasedGame + get rid of Tile.* dependency

### DIFF
--- a/src/main/java/com/fundynamic/d2tm/Game.java
+++ b/src/main/java/com/fundynamic/d2tm/Game.java
@@ -1,45 +1,27 @@
 package com.fundynamic.d2tm;
 
 import com.fundynamic.d2tm.game.state.PlayingState;
-import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.game.terrain.impl.DuneTerrainFactory;
 import com.fundynamic.d2tm.graphics.Theme;
-import org.newdawn.slick.*;
+import org.newdawn.slick.GameContainer;
+import org.newdawn.slick.Image;
+import org.newdawn.slick.SlickException;
+import org.newdawn.slick.state.StateBasedGame;
 import org.newdawn.slick.util.Bootstrap;
 
 
-public class Game extends BasicGame {
+public class Game extends StateBasedGame {
 
     private static final int SCREEN_WIDTH = 800;
     private static final int SCREEN_HEIGHT = 600;
-
-    private PlayingState playingState;
 
     public Game(String title) {
         super(title);
     }
 
-    public void render(GameContainer container, Graphics g) throws SlickException {
-        playingState.init();
-        playingState.render();
-    }
-
     @Override
-    public void init(GameContainer gameContainer) throws SlickException {
-        try {
-            gameContainer.setVSync(true);
-            Theme theme = new Theme(new Image("sheet_terrain.png"));
-            TerrainFactory terrainFactory = new DuneTerrainFactory(theme);
-            playingState = new PlayingState(gameContainer, terrainFactory);
-            // calling init here does not work with images
-        } catch (Exception e) {
-            throw new SlickException("Exception occurred while initializing game.", e);
-        }
-    }
-
-    @Override
-    public void update(GameContainer container, int delta) throws SlickException {
-        playingState.update();
+    public void initStatesList(GameContainer container) throws SlickException {
+        addState(new PlayingState(container, new DuneTerrainFactory(new Theme(new Image("sheet_terrain.png")))));
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/fundynamic/d2tm/Game.java
+++ b/src/main/java/com/fundynamic/d2tm/Game.java
@@ -15,13 +15,32 @@ public class Game extends StateBasedGame {
     private static final int SCREEN_WIDTH = 800;
     private static final int SCREEN_HEIGHT = 600;
 
+    private static final int TILE_WIDTH = 32;
+    private static final int TILE_HEIGHT = 32;
+
     public Game(String title) {
         super(title);
     }
 
     @Override
     public void initStatesList(GameContainer container) throws SlickException {
-        addState(new PlayingState(container, new DuneTerrainFactory(new Theme(new Image("sheet_terrain.png")))));
+        DuneTerrainFactory terrainFactory = new DuneTerrainFactory(
+                new Theme(
+                        new Image("sheet_terrain.png"),
+                        TILE_WIDTH,
+                        TILE_HEIGHT
+                ),
+                TILE_WIDTH,
+                TILE_HEIGHT
+        );
+
+        PlayingState playingState = new PlayingState(
+                container,
+                terrainFactory,
+                TILE_WIDTH,
+                TILE_HEIGHT
+        );
+        addState(playingState);
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
+++ b/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
@@ -3,7 +3,6 @@ package com.fundynamic.d2tm.game.drawing;
 import com.fundynamic.d2tm.game.map.Map;
 import com.fundynamic.d2tm.game.map.Perimeter;
 import com.fundynamic.d2tm.game.math.Vector2D;
-import com.fundynamic.d2tm.graphics.Tile;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
@@ -20,6 +19,9 @@ public class Viewport {
 
     private final Perimeter<Float> viewingVectorPerimeter;
 
+    private final int tileHeight;
+    private final int tileWidth;
+
     private float velocityX;
     private float velocityY;
 
@@ -28,11 +30,11 @@ public class Viewport {
     private Vector2D<Float> viewingVector;
 
 
-    public Viewport(Vector2D screenResolution, Vector2D viewingVector, Graphics graphics, Map map, float moveSpeed) throws SlickException {
-        this(screenResolution, Vector2D.zero(), viewingVector, graphics, map, moveSpeed);
+    public Viewport(Vector2D screenResolution, Vector2D viewingVector, Graphics graphics, Map map, float moveSpeed, int tileWidth, int tileHeight) throws SlickException {
+        this(screenResolution, Vector2D.zero(), viewingVector, graphics, map, moveSpeed, tileWidth, tileHeight);
     }
 
-    public Viewport(Vector2D<Integer> screenResolution, Vector2D drawingVector, Vector2D viewingVector, Graphics graphics, Map map, float moveSpeed) throws SlickException {
+    public Viewport(Vector2D<Integer> screenResolution, Vector2D drawingVector, Vector2D viewingVector, Graphics graphics, Map map, float moveSpeed, int tileWidth, int tileHeight) throws SlickException {
         this.graphics = graphics;
         this.map = map;
 
@@ -40,8 +42,11 @@ public class Viewport {
         this.screenResolution = screenResolution;
         this.buffer = constructImage(screenResolution);
 
-        float heightOfMapInPixels = map.getHeight() * Tile.HEIGHT;
-        float widthOfMapInPixels = map.getWidth() * Tile.WIDTH;
+        this.tileWidth = tileWidth;
+        this.tileHeight = tileHeight;
+
+        float heightOfMapInPixels = map.getHeight() * tileHeight;
+        float widthOfMapInPixels = map.getWidth() * tileWidth;
         this.viewingVectorPerimeter = new Perimeter<>(0F,
                 widthOfMapInPixels - screenResolution.getX(),
                 0F,

--- a/src/main/java/com/fundynamic/d2tm/game/map/Map.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Map.java
@@ -1,7 +1,7 @@
 package com.fundynamic.d2tm.game.map;
 
-import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.game.terrain.Terrain;
+import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.graphics.TerrainFacing;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;

--- a/src/main/java/com/fundynamic/d2tm/game/map/Map.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Map.java
@@ -10,21 +10,25 @@ public class Map {
 
     private final TerrainFactory terrainFactory;
     private final int height, width;
+    private final int tileHeight;
+    private final int tileWidth;
     private Image mapImage;
 
     private Cell[][] cells;
 
-    public Map(TerrainFactory terrainFactory, int width, int height) throws SlickException {
+    public Map(TerrainFactory terrainFactory, int width, int height, int tileWidth, int tileHeight) throws SlickException {
         this.terrainFactory = terrainFactory;
         this.height = height;
         this.width = width;
+        this.tileWidth = tileWidth;
+        this.tileHeight = tileHeight;
 
         initializeEmptyMap(width, height);
     }
 
-    public static Map generateRandom(TerrainFactory terrainFactory, int width, int height) {
+    public static Map generateRandom(TerrainFactory terrainFactory, int width, int height, int tileWidth, int tileHeight) {
         try {
-            Map map = new Map(terrainFactory, width, height);
+            Map map = new Map(terrainFactory, width, height, tileWidth, tileHeight);
             map.putTerrainOnMap();
             map.smooth();
             return map;
@@ -48,7 +52,7 @@ public class Map {
 
     public Image createOrGetMapImage() throws SlickException {
         if (this.mapImage == null) {
-            mapImage = new MapRenderer().render(this);
+            mapImage = new MapRenderer(tileHeight, tileWidth).render(this);
         }
         return mapImage;
     }

--- a/src/main/java/com/fundynamic/d2tm/game/map/Map.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Map.java
@@ -12,14 +12,26 @@ public class Map {
     private final int height, width;
     private Image mapImage;
 
-    private boolean initialized;
-
     private Cell[][] cells;
 
     public Map(TerrainFactory terrainFactory, int width, int height) throws SlickException {
         this.terrainFactory = terrainFactory;
         this.height = height;
         this.width = width;
+
+        initializeEmptyMap(width, height);
+    }
+
+    public static Map generateRandom(TerrainFactory terrainFactory, int width, int height) {
+        try {
+            Map map = new Map(terrainFactory, width, height);
+            map.putTerrainOnMap();
+            map.smooth();
+            return map;
+        } catch (SlickException e) {
+            System.err.println("Exception while creating map with terrainFactory: " + terrainFactory + ", width: " + width + ", height: " + height + ". --> " + e);
+            return null;
+        }
     }
 
     public int getWidth() {
@@ -39,16 +51,6 @@ public class Map {
             mapImage = new MapRenderer().render(this);
         }
         return mapImage;
-    }
-
-    public void init() throws SlickException {
-        if (!initialized) {
-            // this does not work when we move the code in the constructor?
-            initializeEmptyMap(width, height);
-            putTerrainOnMap();
-            smooth();
-            initialized = true;
-        }
     }
 
     private void initializeEmptyMap(int width, int height) {
@@ -128,7 +130,5 @@ public class Map {
             return getCell(x, y - 1).getTerrain();
         }
     }
-
-
 
 }

--- a/src/main/java/com/fundynamic/d2tm/game/map/MapRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/MapRenderer.java
@@ -1,6 +1,5 @@
 package com.fundynamic.d2tm.game.map;
 
-import com.fundynamic.d2tm.graphics.Tile;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
@@ -8,8 +7,16 @@ import org.newdawn.slick.SlickException;
 
 public class MapRenderer {
 
+    private final int tileHeight;
+    private final int tileWidth;
+
+    public MapRenderer(int tileHeight, int tileWidth) {
+        this.tileHeight = tileHeight;
+        this.tileWidth = tileWidth;
+    }
+
     public Image render(Map map) throws SlickException {
-        Image image = makeImage(map.getWidth() * Tile.WIDTH, map.getHeight() * Tile.HEIGHT);
+        Image image = makeImage(map.getWidth() * tileWidth, map.getHeight() * tileHeight);
         renderMap(image.getGraphics(), map);
         return image;
     }
@@ -22,7 +29,7 @@ public class MapRenderer {
         for (int x = 1; x <= map.getWidth(); x++) {
             for (int y = 1; y <= map.getHeight(); y++) {
                 Cell cell = map.getCell(x, y);
-                graphics.drawImage(cell.getTileImage(), (x - 1) * Tile.WIDTH, (y - 1) * Tile.HEIGHT);
+                graphics.drawImage(cell.getTileImage(), (x - 1) * tileWidth, (y - 1) * tileHeight);
             }
         }
     }

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -45,10 +45,7 @@ public class PlayingState extends BasicGameState {
     public void init(GameContainer gameContainer, StateBasedGame game) throws SlickException {
         input.addKeyListener(new QuitGameKeyListener(gameContainer));
 
-        // on map load...
-        this.map = new Map(terrainFactory, 64, 64);
-
-        this.map.init();
+        this.map = Map.generateRandom(terrainFactory, 64, 64);
 
         try {
             float moveSpeed = 16.0F;

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -24,13 +24,18 @@ public class PlayingState extends BasicGameState {
     private final Input input;
     private final Vector2D<Integer> screenResolution;
 
+    private final int tileWidth;
+    private final int tileHeight;
+
     private Map map;
     private Graphics graphics;
 
     private List<Viewport> viewports = new ArrayList<>();
 
-    public PlayingState(GameContainer gameContainer, TerrainFactory terrainFactory) throws SlickException {
+    public PlayingState(GameContainer gameContainer, TerrainFactory terrainFactory, int tileWidth, int tileHeight) throws SlickException {
         this.terrainFactory = terrainFactory;
+        this.tileWidth = tileWidth;
+        this.tileHeight = tileHeight;
         this.graphics = gameContainer.getGraphics();
         this.input = gameContainer.getInput();
         this.screenResolution = new Vector2D<>(gameContainer.getWidth(), gameContainer.getHeight());
@@ -45,12 +50,12 @@ public class PlayingState extends BasicGameState {
     public void init(GameContainer gameContainer, StateBasedGame game) throws SlickException {
         input.addKeyListener(new QuitGameKeyListener(gameContainer));
 
-        this.map = Map.generateRandom(terrainFactory, 64, 64);
+        this.map = Map.generateRandom(terrainFactory, 64, 64, tileWidth, tileHeight);
 
         try {
             float moveSpeed = 16.0F;
             Vector2D viewportDrawingPosition = Vector2D.zero();
-            Viewport viewport = new Viewport(screenResolution, viewportDrawingPosition, Vector2D.zero(), graphics, this.map, moveSpeed);
+            Viewport viewport = new Viewport(screenResolution, viewportDrawingPosition, Vector2D.zero(), graphics, this.map, moveSpeed, tileWidth, tileHeight);
 
             // Add listener for this viewport
             input.addMouseListener(new ViewportMovementListener(viewport, screenResolution));

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -10,69 +10,71 @@ import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Input;
 import org.newdawn.slick.SlickException;
+import org.newdawn.slick.state.BasicGameState;
+import org.newdawn.slick.state.StateBasedGame;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class PlayingState {
+public class PlayingState extends BasicGameState {
+
+    public static int ID = 0;
 
     private final TerrainFactory terrainFactory;
+    private final Input input;
+    private final Vector2D<Integer> screenResolution;
 
     private Map map;
     private Graphics graphics;
 
     private List<Viewport> viewports = new ArrayList<>();
 
-    private boolean initialized;
-    private final Input input;
-    private Vector2D<Integer> screenResolution;
-
-
     public PlayingState(GameContainer gameContainer, TerrainFactory terrainFactory) throws SlickException {
         this.terrainFactory = terrainFactory;
         this.graphics = gameContainer.getGraphics();
+        this.input = gameContainer.getInput();
+        this.screenResolution = new Vector2D<>(gameContainer.getWidth(), gameContainer.getHeight());
+    }
 
-        input = gameContainer.getInput();
+    @Override
+    public int getID() {
+        return ID;
+    }
+
+    @Override
+    public void init(GameContainer gameContainer, StateBasedGame game) throws SlickException {
         input.addKeyListener(new QuitGameKeyListener(gameContainer));
 
         // on map load...
         this.map = new Map(terrainFactory, 64, 64);
 
-        this.screenResolution = new Vector2D<>(gameContainer.getWidth(), gameContainer.getHeight());
-    }
+        this.map.init();
 
-    public void init() throws SlickException {
-        // HACK HACK: we call init in render, and we only want to do it once so we check here. Ugly because now we check
-        // every iteration if we should do this...
-        if (!initialized) {
-            this.map.init();
-            initialized = true;
+        try {
+            float moveSpeed = 16.0F;
+            Vector2D viewportDrawingPosition = Vector2D.zero();
+            Viewport viewport = new Viewport(screenResolution, viewportDrawingPosition, Vector2D.zero(), graphics, this.map, moveSpeed);
 
-            try {
-                float moveSpeed = 16.0F;
-                Vector2D viewportDrawingPosition = Vector2D.zero();
-                Viewport viewport = new Viewport(screenResolution, viewportDrawingPosition, Vector2D.zero(), graphics, this.map, moveSpeed);
+            // Add listener for this viewport
+            input.addMouseListener(new ViewportMovementListener(viewport, screenResolution));
 
-                // Add listener for this viewport
-                input.addMouseListener(new ViewportMovementListener(viewport, screenResolution));
-
-                viewports.add(viewport);
-            } catch (SlickException e) {
-                throw new IllegalStateException("Unable to create new viewport!", e);
-            }
+            viewports.add(viewport);
+        } catch (SlickException e) {
+            throw new IllegalStateException("Unable to create new viewport!", e);
         }
     }
 
-    public void update() {
-        for (Viewport viewport : viewports) {
-            viewport.update();
-        }
-    }
-
-    public void render() throws SlickException {
+    @Override
+    public void render(GameContainer container, StateBasedGame game, Graphics g) throws SlickException {
         for (Viewport viewport : viewports) {
             viewport.render();
         }
     }
 
+    @Override
+    public void update(GameContainer container, StateBasedGame game, int delta) throws SlickException {
+        for (Viewport viewport : viewports) {
+            viewport.update();
+        }
+    }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/terrain/impl/DuneTerrainFactory.java
+++ b/src/main/java/com/fundynamic/d2tm/game/terrain/impl/DuneTerrainFactory.java
@@ -8,9 +8,13 @@ import com.fundynamic.d2tm.graphics.Theme;
 public class DuneTerrainFactory implements TerrainFactory {
 
     private final Theme theme;
+    private final int tileWidth;
+    private final int tileHeight;
 
-    public DuneTerrainFactory(Theme theme) {
+    public DuneTerrainFactory(Theme theme, int tileWidth, int tileHeight) {
         this.theme = theme;
+        this.tileWidth = tileWidth;
+        this.tileHeight = tileHeight;
     }
 
     public Terrain create(int terrainType, Cell cell) {
@@ -35,6 +39,6 @@ public class DuneTerrainFactory implements TerrainFactory {
     }
 
     public Terrain createEmptyTerrain() {
-        return new EmptyTerrain();
+        return new EmptyTerrain(tileWidth, tileHeight);
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/terrain/impl/DuneTerrainFactory.java
+++ b/src/main/java/com/fundynamic/d2tm/game/terrain/impl/DuneTerrainFactory.java
@@ -1,8 +1,8 @@
 package com.fundynamic.d2tm.game.terrain.impl;
 
-import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.game.map.Cell;
 import com.fundynamic.d2tm.game.terrain.Terrain;
+import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.graphics.Theme;
 
 public class DuneTerrainFactory implements TerrainFactory {

--- a/src/main/java/com/fundynamic/d2tm/game/terrain/impl/EmptyTerrain.java
+++ b/src/main/java/com/fundynamic/d2tm/game/terrain/impl/EmptyTerrain.java
@@ -2,7 +2,6 @@ package com.fundynamic.d2tm.game.terrain.impl;
 
 import com.fundynamic.d2tm.game.terrain.Terrain;
 import com.fundynamic.d2tm.graphics.TerrainFacing;
-import com.fundynamic.d2tm.graphics.Tile;
 import org.newdawn.slick.Color;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
@@ -13,12 +12,12 @@ public class EmptyTerrain implements Terrain {
     private final Image image;
     private static Image blackImage = null;
 
-    public EmptyTerrain() {
+    public EmptyTerrain(int tileWidth, int tileHeight) {
         try {
             if (blackImage == null) {
-                blackImage = new Image(Tile.WIDTH, Tile.HEIGHT);
+                blackImage = new Image(tileWidth, tileHeight);
                 blackImage.getGraphics().setColor(Color.black);
-                blackImage.getGraphics().fillRect(0, 0, Tile.WIDTH, Tile.HEIGHT);
+                blackImage.getGraphics().fillRect(0, 0, tileWidth, tileHeight);
             }
             this.image = blackImage;
         } catch (SlickException e) {

--- a/src/main/java/com/fundynamic/d2tm/graphics/Theme.java
+++ b/src/main/java/com/fundynamic/d2tm/graphics/Theme.java
@@ -8,8 +8,8 @@ public class Theme {
 
     private final SpriteSheet spriteSheet;
 
-    public Theme(Image image) {
-        this.spriteSheet = new SpriteSheet(image, Tile.WIDTH, Tile.HEIGHT);
+    public Theme(Image image, int tileWidth, int tileHeight) {
+        this.spriteSheet = new SpriteSheet(image, tileWidth, tileHeight);
     }
 
     public Image getTileImage(int row, TerrainFacing facing) {

--- a/src/main/java/com/fundynamic/d2tm/graphics/Tile.java
+++ b/src/main/java/com/fundynamic/d2tm/graphics/Tile.java
@@ -1,8 +1,0 @@
-package com.fundynamic.d2tm.graphics;
-
-public class Tile {
-
-    public static int WIDTH = 32;
-    public static int HEIGHT = 32;
-
-}

--- a/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
@@ -5,7 +5,6 @@ import com.fundynamic.d2tm.game.map.Map;
 import com.fundynamic.d2tm.game.math.Vector2D;
 import com.fundynamic.d2tm.game.terrain.Terrain;
 import com.fundynamic.d2tm.game.terrain.TerrainFactory;
-import com.fundynamic.d2tm.game.terrain.impl.EmptyTerrain;
 import com.fundynamic.d2tm.graphics.Tile;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
@@ -3,6 +3,9 @@ package com.fundynamic.d2tm.game.event;
 import com.fundynamic.d2tm.game.drawing.Viewport;
 import com.fundynamic.d2tm.game.map.Map;
 import com.fundynamic.d2tm.game.math.Vector2D;
+import com.fundynamic.d2tm.game.terrain.Terrain;
+import com.fundynamic.d2tm.game.terrain.TerrainFactory;
+import com.fundynamic.d2tm.game.terrain.impl.EmptyTerrain;
 import com.fundynamic.d2tm.graphics.Tile;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +38,9 @@ public class ViewportMovementListenerTest {
 
     @Before
     public void setUp() throws SlickException {
-        map = new Map(null, WIDTH_OF_MAP, HEIGHT_OF_MAP);
+        TerrainFactory terrainFactory = Mockito.mock(TerrainFactory.class);
+        Mockito.doReturn(Mockito.mock(Terrain.class)).when(terrainFactory).createEmptyTerrain();
+        map = new Map(terrainFactory, WIDTH_OF_MAP, HEIGHT_OF_MAP);
         screenResolution = new Vector2D<>(800, 600);
 
         viewport = makeDrawableViewPort(INITIAL_VIEWPORT_X, INITIAL_VIEWPORT_Y, MOVE_SPEED);

--- a/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
@@ -5,7 +5,6 @@ import com.fundynamic.d2tm.game.map.Map;
 import com.fundynamic.d2tm.game.math.Vector2D;
 import com.fundynamic.d2tm.game.terrain.Terrain;
 import com.fundynamic.d2tm.game.terrain.TerrainFactory;
-import com.fundynamic.d2tm.graphics.Tile;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +20,9 @@ import static org.mockito.Mockito.mock;
 @RunWith(MockitoJUnitRunner.class)
 public class ViewportMovementListenerTest {
     public static final float MOVE_SPEED = 2.0F;
+
+    private static final int TILE_WIDTH = 32;
+    private static final int TILE_HEIGHT = 32;
 
     public static final int ANY_COORDINATE_NOT_NEAR_BORDER = 100;
     public static final float INITIAL_VIEWPORT_X = 4F;
@@ -39,7 +41,7 @@ public class ViewportMovementListenerTest {
     public void setUp() throws SlickException {
         TerrainFactory terrainFactory = Mockito.mock(TerrainFactory.class);
         Mockito.doReturn(Mockito.mock(Terrain.class)).when(terrainFactory).createEmptyTerrain();
-        map = new Map(terrainFactory, WIDTH_OF_MAP, HEIGHT_OF_MAP);
+        map = new Map(terrainFactory, WIDTH_OF_MAP, HEIGHT_OF_MAP, TILE_WIDTH, TILE_HEIGHT);
         screenResolution = new Vector2D<>(800, 600);
 
         viewport = makeDrawableViewPort(INITIAL_VIEWPORT_X, INITIAL_VIEWPORT_Y, MOVE_SPEED);
@@ -47,7 +49,7 @@ public class ViewportMovementListenerTest {
     }
 
     private Viewport makeDrawableViewPort(float viewportX, float viewportY, float moveSpeed) throws SlickException {
-        return new Viewport(screenResolution, Vector2D.zero(), new Vector2D<>(viewportX, viewportY), mock(Graphics.class), map, moveSpeed) {
+        return new Viewport(screenResolution, Vector2D.zero(), new Vector2D<>(viewportX, viewportY), mock(Graphics.class), map, moveSpeed, TILE_WIDTH, TILE_HEIGHT) {
             // ugly seam in the code, but I'd rather do this than create a Spy
             @Override
             protected Image constructImage(Vector2D<Integer> screenResolution) throws SlickException {
@@ -162,7 +164,7 @@ public class ViewportMovementListenerTest {
         int viewportY = 0;
         float moveSpeed = 16F;
 
-        float maxYViewportPosition = (HEIGHT_OF_MAP * Tile.HEIGHT) - screenResolution.getY();
+        float maxYViewportPosition = (HEIGHT_OF_MAP * TILE_HEIGHT) - screenResolution.getY();
 
         viewport = makeDrawableViewPort(viewportX, viewportY, moveSpeed);
         listener = new ViewportMovementListener(viewport, screenResolution);
@@ -182,7 +184,7 @@ public class ViewportMovementListenerTest {
         int viewportY = 0;
         float moveSpeed = 32F;
 
-        float maxXViewportPosition = (WIDTH_OF_MAP * Tile.WIDTH) - screenResolution.getX();
+        float maxXViewportPosition = (WIDTH_OF_MAP * TILE_WIDTH) - screenResolution.getX();
 
         viewport = makeDrawableViewPort(viewportX, viewportY, moveSpeed);
         listener = new ViewportMovementListener(viewport, screenResolution);

--- a/src/test/java/com/fundynamic/d2tm/game/map/MapRendererTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/map/MapRendererTest.java
@@ -1,7 +1,5 @@
 package com.fundynamic.d2tm.game.map;
 
-import static org.junit.Assert.*;
-
 import com.fundynamic.d2tm.game.TestableImage;
 import junit.framework.Assert;
 import org.junit.Test;

--- a/src/test/java/com/fundynamic/d2tm/game/map/MapRendererTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/map/MapRendererTest.java
@@ -16,9 +16,13 @@ import static org.mockito.Matchers.*;
 @RunWith(MockitoJUnitRunner.class)
 public class MapRendererTest {
 
+    private static final int TILE_WIDTH = 32;
+    private static final int TILE_HEIGHT = 32;
+
     private static final int ANY_WIDTH = 0;
     private static final int ANY_HEIGHT = 0;
     private static final Cell ANY_CELL = Mockito.mock(Cell.class);
+
 
     @Mock
     private Graphics graphics;
@@ -116,6 +120,10 @@ public class MapRendererTest {
     }
 
     private class TestingMapRenderer extends MapRenderer {
+
+        private TestingMapRenderer() {
+            super(TILE_WIDTH, TILE_HEIGHT);
+        }
 
         @Override
         protected Image makeImage(int width, int height) throws SlickException {


### PR DESCRIPTION
this solves:
- the weird initialization of the map and game (using that flag)

this exposes:
- all kinds of dependencies on the tile width and height. So we can think about it (later) how to make that more sensible.