### PR TITLE
Decouple viewport scrolling speed from FPS

### DIFF
--- a/src/main/java/com/fundynamic/d2tm/Game.java
+++ b/src/main/java/com/fundynamic/d2tm/Game.java
@@ -19,8 +19,6 @@ public class Game extends StateBasedGame {
     private static final int TILE_WIDTH = 32;
     private static final int TILE_HEIGHT = 32;
 
-    private static final int MIN_DELTA_BETWEEN_FRAMES = 10;
-
     public Game(String title) {
         super(title);
     }
@@ -36,8 +34,6 @@ public class Game extends StateBasedGame {
                 TILE_WIDTH,
                 TILE_HEIGHT
         );
-
-        container.setMinimumLogicUpdateInterval(MIN_DELTA_BETWEEN_FRAMES);
 
         PlayingState playingState = new PlayingState(
                 container,

--- a/src/main/java/com/fundynamic/d2tm/Game.java
+++ b/src/main/java/com/fundynamic/d2tm/Game.java
@@ -37,7 +37,7 @@ public class Game extends StateBasedGame {
                 TILE_HEIGHT
         );
 
-        container.setVSync(true);
+//        container.setVSync(true);
         container.setMinimumLogicUpdateInterval(MIN_DELTA_BETWEEN_FRAMES);
 
         PlayingState playingState = new PlayingState(

--- a/src/main/java/com/fundynamic/d2tm/Game.java
+++ b/src/main/java/com/fundynamic/d2tm/Game.java
@@ -19,6 +19,8 @@ public class Game extends StateBasedGame {
     private static final int TILE_WIDTH = 32;
     private static final int TILE_HEIGHT = 32;
 
+    private static final int MIN_DELTA_BETWEEN_FRAMES = 10;
+
     public Game(String title) {
         super(title);
     }
@@ -36,6 +38,7 @@ public class Game extends StateBasedGame {
         );
 
         container.setVSync(true);
+        container.setMinimumLogicUpdateInterval(MIN_DELTA_BETWEEN_FRAMES);
 
         PlayingState playingState = new PlayingState(
                 container,

--- a/src/main/java/com/fundynamic/d2tm/Game.java
+++ b/src/main/java/com/fundynamic/d2tm/Game.java
@@ -37,7 +37,6 @@ public class Game extends StateBasedGame {
                 TILE_HEIGHT
         );
 
-//        container.setVSync(true);
         container.setMinimumLogicUpdateInterval(MIN_DELTA_BETWEEN_FRAMES);
 
         PlayingState playingState = new PlayingState(

--- a/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
+++ b/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
@@ -8,7 +8,6 @@ import com.fundynamic.d2tm.game.math.Vector2D;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
-import org.newdawn.slick.geom.Vector2f;
 
 public class Viewport {
 

--- a/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
+++ b/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
@@ -76,7 +76,7 @@ public class Viewport {
         mapCellViewportRenderer.render(this.buffer, viewingVector, mapCellTerrainRenderer);
         structureViewportRenderer.render(this.buffer, viewingVector, structureRenderer);
         mapCellViewportRenderer.render(this.buffer, viewingVector, mapCellMouseInteractionRenderer);
-//        mapRenderer.render(this.buffer, viewingVector, shroudRenderer);
+        mapCellViewportRenderer.render(this.buffer, viewingVector, mapCellShroudRenderer);
 
         drawBufferToGraphics(graphics, drawingVector);
     }

--- a/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
+++ b/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
@@ -8,6 +8,7 @@ import com.fundynamic.d2tm.game.math.Vector2D;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
+import org.newdawn.slick.geom.Vector2f;
 
 public class Viewport {
 
@@ -30,17 +31,16 @@ public class Viewport {
     private final MapCellMouseInteractionRenderer mapCellMouseInteractionRenderer;
     private final MapCellViewportRenderer mapCellViewportRenderer;
 
-    private Vector2D velocity;
-
+    private Vector2f velocity;
     private float moveSpeed;
 
-    private Vector2D viewingVector;
+    private Vector2f viewingVector;
 
     private Map map;
 
     public Viewport(Vector2D viewportDimensions,
                     Vector2D drawingVector,
-                    Vector2D viewingVector,
+                    Vector2f viewingVector,
                     Graphics graphics,
                     Map map,
                     float moveSpeed,
@@ -56,7 +56,7 @@ public class Viewport {
 
         this.viewingVectorPerimeter = map.createViewablePerimeter(viewportDimensions, tileWidth, tileHeight);
         this.viewingVector = viewingVector;
-        this.velocity = Vector2D.zero();
+        this.velocity = new Vector2f(0, 0);
 
         this.moveSpeed = moveSpeed;
 
@@ -81,33 +81,33 @@ public class Viewport {
         drawBufferToGraphics(graphics, drawingVector);
     }
 
-    public void update() {
-        Vector2D newViewingVector = viewingVectorPerimeter.makeSureVectorStaysWithin(viewingVector.move(velocity));
-        viewingVector = newViewingVector;
+    public void update(float delta) {
+        Vector2f translation = velocity.copy().scale(delta);
+        viewingVector = viewingVectorPerimeter.makeSureVectorStaysWithin(viewingVector.copy().add(translation));
     }
 
     private void moveLeft() {
-        this.velocity = new Vector2D(-moveSpeed, this.velocity.getY());
+        this.velocity = new Vector2f(-moveSpeed, this.velocity.getY());
     }
 
     private void moveRight() {
-        this.velocity = new Vector2D(moveSpeed, this.velocity.getY());
+        this.velocity = new Vector2f(moveSpeed, this.velocity.getY());
     }
 
     private void moveUp() {
-        this.velocity = new Vector2D(this.velocity.getX(), -moveSpeed);
+        this.velocity = new Vector2f(this.velocity.getX(), -moveSpeed);
     }
 
     private void moveDown() {
-        this.velocity = new Vector2D(this.velocity.getX(), moveSpeed);
+        this.velocity = new Vector2f(this.velocity.getX(), moveSpeed);
     }
 
     private void stopMovingHorizontally() {
-        this.velocity = new Vector2D(0, this.velocity.getY());
+        this.velocity = new Vector2f(0, this.velocity.getY());
     }
 
     private void stopMovingVertically() {
-        this.velocity = new Vector2D(this.velocity.getX(), 0);
+        this.velocity = new Vector2f(this.velocity.getX(), 0);
     }
 
     private void drawBufferToGraphics(Graphics graphics, Vector2D drawingVector) {
@@ -116,7 +116,7 @@ public class Viewport {
 
     // These methods are here mainly for (easier) testing. Best would be to remove them if possible - and at the very
     // least not the use them in the non-test code.
-    public Vector2D getViewingVector() {
+    public Vector2f getViewingVector() {
         return viewingVector;
     }
 
@@ -150,13 +150,13 @@ public class Viewport {
      * Takes screen pixel coordinate and translates that into an absolute pixel coordinate on the map
      */
     public int getAbsoluteX(int xPositionOnScreen) {
-        return xPositionOnScreen + viewingVector.getX();
+        return xPositionOnScreen + (int)viewingVector.getX();
     }
 
     /**
      * Takes screen pixel coordinate and translates that into an absolute pixel coordinate on the map
      */
     public int getAbsoluteY(int yPositionOnScreen) {
-        return yPositionOnScreen + viewingVector.getY();
+        return yPositionOnScreen + (int)viewingVector.getY();
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
+++ b/src/main/java/com/fundynamic/d2tm/game/drawing/Viewport.java
@@ -31,16 +31,16 @@ public class Viewport {
     private final MapCellMouseInteractionRenderer mapCellMouseInteractionRenderer;
     private final MapCellViewportRenderer mapCellViewportRenderer;
 
-    private Vector2f velocity;
+    private Vector2D velocity;
     private float moveSpeed;
 
-    private Vector2f viewingVector;
+    private Vector2D viewingVector;
 
     private Map map;
 
     public Viewport(Vector2D viewportDimensions,
                     Vector2D drawingVector,
-                    Vector2f viewingVector,
+                    Vector2D viewingVector,
                     Graphics graphics,
                     Map map,
                     float moveSpeed,
@@ -56,7 +56,7 @@ public class Viewport {
 
         this.viewingVectorPerimeter = map.createViewablePerimeter(viewportDimensions, tileWidth, tileHeight);
         this.viewingVector = viewingVector;
-        this.velocity = new Vector2f(0, 0);
+        this.velocity = Vector2D.zero();
 
         this.moveSpeed = moveSpeed;
 
@@ -82,32 +82,32 @@ public class Viewport {
     }
 
     public void update(float delta) {
-        Vector2f translation = velocity.copy().scale(delta);
-        viewingVector = viewingVectorPerimeter.makeSureVectorStaysWithin(viewingVector.copy().add(translation));
+        Vector2D translation = velocity.scale(delta);
+        viewingVector = viewingVectorPerimeter.makeSureVectorStaysWithin(viewingVector.add(translation));
     }
 
     private void moveLeft() {
-        this.velocity = new Vector2f(-moveSpeed, this.velocity.getY());
+        this.velocity = Vector2D.create(-moveSpeed, this.velocity.getY());
     }
 
     private void moveRight() {
-        this.velocity = new Vector2f(moveSpeed, this.velocity.getY());
+        this.velocity = Vector2D.create(moveSpeed, this.velocity.getY());
     }
 
     private void moveUp() {
-        this.velocity = new Vector2f(this.velocity.getX(), -moveSpeed);
+        this.velocity = Vector2D.create(this.velocity.getX(), -moveSpeed);
     }
 
     private void moveDown() {
-        this.velocity = new Vector2f(this.velocity.getX(), moveSpeed);
+        this.velocity = Vector2D.create(this.velocity.getX(), moveSpeed);
     }
 
     private void stopMovingHorizontally() {
-        this.velocity = new Vector2f(0, this.velocity.getY());
+        this.velocity = Vector2D.create(0, this.velocity.getY());
     }
 
     private void stopMovingVertically() {
-        this.velocity = new Vector2f(this.velocity.getX(), 0);
+        this.velocity = Vector2D.create(this.velocity.getX(), 0);
     }
 
     private void drawBufferToGraphics(Graphics graphics, Vector2D drawingVector) {
@@ -116,12 +116,12 @@ public class Viewport {
 
     // These methods are here mainly for (easier) testing. Best would be to remove them if possible - and at the very
     // least not the use them in the non-test code.
-    public Vector2f getViewingVector() {
+    public Vector2D getViewingVector() {
         return viewingVector;
     }
 
     protected Image constructImage(Vector2D screenResolution) throws SlickException {
-        return new Image(screenResolution.getX(), screenResolution.getY());
+        return new Image(screenResolution.getXAsInt(), screenResolution.getYAsInt());
     }
 
     public Map getMap() {

--- a/src/main/java/com/fundynamic/d2tm/game/map/Cell.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Cell.java
@@ -11,21 +11,18 @@ public class Cell {
 
     private Terrain terrain;
     private boolean shrouded;
-    private boolean topLeftOfStructure;
 
     protected Cell(Terrain terrain) {
         if (terrain == null) throw new IllegalArgumentException("Terrain argument may not be null");
         this.terrain = terrain;
         this.shrouded = true;
         this.structure = null;
-        this.topLeftOfStructure = false;
     }
 
     protected Cell(Cell other) {
         if (other == null) throw new IllegalArgumentException("argument for copy constructor may not be null (cannot copy from NULL)");
         this.terrain = other.getTerrain();
         this.shrouded = other.isShrouded();
-        this.topLeftOfStructure = other.isTopLeftOfStructure();
         this.structure = other.getStructure();
     }
 
@@ -73,14 +70,6 @@ public class Cell {
     public boolean hasStructure(Structure selectedStructure) {
         if (this.structure == null) return false;
         return this.structure == selectedStructure;
-    }
-
-    public void setTopLeftOfStructure(boolean topLeftOfStructure) {
-        this.topLeftOfStructure = topLeftOfStructure;
-    }
-
-    public boolean isTopLeftOfStructure() {
-        return topLeftOfStructure;
     }
 
 }

--- a/src/main/java/com/fundynamic/d2tm/game/map/Map.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Map.java
@@ -3,6 +3,7 @@ package com.fundynamic.d2tm.game.map;
 import com.fundynamic.d2tm.game.map.renderer.TerrainFacingDeterminer;
 import com.fundynamic.d2tm.game.math.Vector2D;
 import com.fundynamic.d2tm.game.structures.Structure;
+import com.fundynamic.d2tm.game.structures.StructuresRepository;
 import com.fundynamic.d2tm.game.terrain.Terrain;
 import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.graphics.Shroud;
@@ -22,6 +23,7 @@ public class Map {
     private final int heightWithInvisibleBorder, widthWithInvisibleBorder;
 
     private Cell[][] cells;
+    private Set<Structure> structures;
 
     public Map(TerrainFactory terrainFactory, Shroud shroud, int width, int height) throws SlickException {
         this.terrainFactory = terrainFactory;
@@ -30,6 +32,7 @@ public class Map {
         this.width = width;
         this.heightWithInvisibleBorder = height + 2;
         this.widthWithInvisibleBorder = width + 2;
+        this.structures = new HashSet<>();
 
         initializeEmptyMap();
     }
@@ -142,20 +145,20 @@ public class Map {
         return new MapCell(this, pixelX / TILE_SIZE, pixelY / TILE_SIZE);
     }
 
-    public Set<Structure> getStructures() {
-        // TODO: This is a sub-optimal way to get all structures. It would be
-        // better to append it to an in-memory list when the structure is added
-        // to the map.
-        Set<Structure> structures = new HashSet<>();
-        for (int x = 1; x <= this.width; x++) {
-            for (int y = 1; y <= this.height; y++) {
-                Structure structure = getCell(x, y).getStructure();
-                if (structure != null) {
-                    structures.add(structure);
-                }
+    public Set<Structure> getStructures() { return structures; }
+
+    public void placeStructure(Vector2D topLeft, Structure structure, StructuresRepository.StructureData data) {
+        int widthInCells = data.width / TILE_SIZE;
+        int heightInCells = data.height / TILE_SIZE;
+
+        getCell(topLeft.getXAsInt(), topLeft.getYAsInt()).setStructure(structure).setTopLeftOfStructure(true);
+        for (int x = 0; x < widthInCells; x++) {
+            for (int y = 0; y < heightInCells; y++) {
+                getCell(topLeft.getXAsInt() + x, topLeft.getYAsInt() + y).setStructure(structure);
             }
         }
-        return structures;
+
+        structures.add(structure);
     }
 
     // We also have a MapCell, they both are the same!? (somewhat?)

--- a/src/main/java/com/fundynamic/d2tm/game/map/Map.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Map.java
@@ -147,14 +147,14 @@ public class Map {
 
     public Set<Structure> getStructures() { return structures; }
 
-    public void placeStructure(Vector2D topLeft, Structure structure, StructuresRepository.StructureData data) {
+    public void placeStructure(Structure structure, StructuresRepository.StructureData data) {
+        Vector2D topLeftMapCoordinates = structure.getMapCoordinates();
         int widthInCells = data.width / TILE_SIZE;
         int heightInCells = data.height / TILE_SIZE;
 
-        getCell(topLeft.getXAsInt(), topLeft.getYAsInt()).setStructure(structure).setTopLeftOfStructure(true);
         for (int x = 0; x < widthInCells; x++) {
             for (int y = 0; y < heightInCells; y++) {
-                getCell(topLeft.getXAsInt() + x, topLeft.getYAsInt() + y).setStructure(structure);
+                getCell(topLeftMapCoordinates.getXAsInt() + x, topLeftMapCoordinates.getYAsInt() + y).setStructure(structure);
             }
         }
 

--- a/src/main/java/com/fundynamic/d2tm/game/map/Map.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Map.java
@@ -2,11 +2,15 @@ package com.fundynamic.d2tm.game.map;
 
 import com.fundynamic.d2tm.game.map.renderer.TerrainFacingDeterminer;
 import com.fundynamic.d2tm.game.math.Vector2D;
+import com.fundynamic.d2tm.game.structures.Structure;
 import com.fundynamic.d2tm.game.terrain.Terrain;
 import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.graphics.Shroud;
 import com.fundynamic.d2tm.graphics.TerrainFacing;
 import org.newdawn.slick.SlickException;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class Map {
 
@@ -136,6 +140,22 @@ public class Map {
 
     public MapCell getCellByAbsolutePixelCoordinates(int pixelX, int pixelY) {
         return new MapCell(this, pixelX / TILE_SIZE, pixelY / TILE_SIZE);
+    }
+
+    public Set<Structure> getStructures() {
+        // TODO: This is a sub-optimal way to get all structures. It would be
+        // better to append it to an in-memory list when the structure is added
+        // to the map.
+        Set<Structure> structures = new HashSet<>();
+        for (int x = 1; x <= this.width; x++) {
+            for (int y = 1; y <= this.height; y++) {
+                Structure structure = getCell(x, y).getStructure();
+                if (structure != null) {
+                    structures.add(structure);
+                }
+            }
+        }
+        return structures;
     }
 
     // We also have a MapCell, they both are the same!? (somewhat?)

--- a/src/main/java/com/fundynamic/d2tm/game/map/Perimeter.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Perimeter.java
@@ -1,6 +1,6 @@
 package com.fundynamic.d2tm.game.map;
 
-import org.newdawn.slick.geom.Vector2f;
+import com.fundynamic.d2tm.game.math.Vector2D;
 
 public class Perimeter {
 
@@ -16,9 +16,10 @@ public class Perimeter {
         this.maxY = maxY;
     }
 
-    public Vector2f makeSureVectorStaysWithin(Vector2f vec) {
+    // TODO: Write test for this?
+    public Vector2D makeSureVectorStaysWithin(Vector2D vec) {
         float x = Math.min(Math.max(vec.getX(), minX), maxX);
         float y = Math.min(Math.max(vec.getY(), minY), maxY);
-        return new Vector2f(x, y);
+        return Vector2D.create(x, y);
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/map/Perimeter.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Perimeter.java
@@ -16,7 +16,6 @@ public class Perimeter {
         this.maxY = maxY;
     }
 
-    // TODO: Write test for this?
     public Vector2D makeSureVectorStaysWithin(Vector2D vec) {
         float x = Math.min(Math.max(vec.getX(), minX), maxX);
         float y = Math.min(Math.max(vec.getY(), minY), maxY);

--- a/src/main/java/com/fundynamic/d2tm/game/map/Perimeter.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/Perimeter.java
@@ -1,12 +1,11 @@
 package com.fundynamic.d2tm.game.map;
 
-import com.fundynamic.d2tm.game.math.Vector2D;
+import org.newdawn.slick.geom.Vector2f;
 
 public class Perimeter {
 
     private final float minX;
     private final float maxX;
-
     private final float minY;
     private final float maxY;
 
@@ -17,13 +16,9 @@ public class Perimeter {
         this.maxY = maxY;
     }
 
-    public Vector2D makeSureVectorStaysWithin(Vector2D vec) {
-        float vecX = vec.getX();
-        float vecY = vec.getY();
-        if (vecX < minX) vecX = minX;
-        if (vecX > maxX) vecX = maxX;
-        if (vecY < minY) vecY = minY;
-        if (vecY > maxY) vecY = maxY;
-        return new Vector2D(vecX, vecY);
+    public Vector2f makeSureVectorStaysWithin(Vector2f vec) {
+        float x = Math.min(Math.max(vec.getX(), minX), maxX);
+        float y = Math.min(Math.max(vec.getY(), minY), maxY);
+        return new Vector2f(x, y);
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/MapCellShroudRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/MapCellShroudRenderer.java
@@ -29,9 +29,9 @@ public class MapCellShroudRenderer implements Renderer<MapCell> {
 
         return getFacing(
                 mapCell.getCellAbove().isShrouded(),
-                mapCell.getCellLeft().isShrouded(),
+                mapCell.getCellRight().isShrouded(),
                 mapCell.getCellBeneath().isShrouded(),
-                mapCell.getCellRight().isShrouded());
+                mapCell.getCellLeft().isShrouded());
     }
 
     public static ShroudFacing getFacing(boolean isTopShrouded, boolean isRightShrouded, boolean isBottomShrouded, boolean isLeftShrouded) {

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRenderer.java
@@ -23,21 +23,21 @@ public class MapCellViewportRenderer implements ViewportRenderer<MapCell> {
         this.map = map;
         this.tileHeight = tileHeight;
         this.tileWidth = tileWidth;
-        cellsThatFitHorizontally = (windowDimensions.getX() / tileWidth) + 1;
-        cellsThatFitVertically = (windowDimensions.getY() / tileHeight) + 1;
+        cellsThatFitHorizontally = (windowDimensions.getXAsInt() / tileWidth) + 1;
+        cellsThatFitVertically = (windowDimensions.getYAsInt() / tileHeight) + 1;
     }
 
-    public void render(Image imageToDrawOn, Vector2f viewingVector, Renderer<MapCell> renderer) throws SlickException {
-        int startCellX = (int)(viewingVector.getX() / tileWidth);
-        int startCellY = (int)(viewingVector.getY() / tileHeight);
+    public void render(Image imageToDrawOn, Vector2D viewingVector, Renderer<MapCell> renderer) throws SlickException {
+        int startCellX = viewingVector.getXAsInt() / tileWidth;
+        int startCellY = viewingVector.getYAsInt() / tileHeight;
 
         int endCellX = startCellX + cellsThatFitHorizontally;
         int endCellY = startCellY + cellsThatFitVertically;
 
         for (int x = startCellX; x <= endCellX; x++) {
             for (int y = startCellY; y <= endCellY; y++) {
-                int drawX = ((x - startCellX) * tileWidth) - ((int)viewingVector.getX() % tileWidth);
-                int drawY = ((y - startCellY) * tileHeight) - ((int)viewingVector.getY() % tileHeight);
+                int drawX = ((x - startCellX) * tileWidth) - (viewingVector.getXAsInt() % tileWidth);
+                int drawY = ((y - startCellY) * tileHeight) - (viewingVector.getYAsInt() % tileHeight);
 
                 renderer.draw(imageToDrawOn.getGraphics(), new MapCell(map, x, y), drawX, drawY);
             }

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRenderer.java
@@ -5,6 +5,7 @@ import com.fundynamic.d2tm.game.map.MapCell;
 import com.fundynamic.d2tm.game.math.Vector2D;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
+import org.newdawn.slick.geom.Vector2f;
 
 /**
  * Responsible for selecting cells in view and calling the renderer for those drawing positions.
@@ -26,17 +27,17 @@ public class MapCellViewportRenderer implements ViewportRenderer<MapCell> {
         cellsThatFitVertically = (windowDimensions.getY() / tileHeight) + 1;
     }
 
-    public void render(Image imageToDrawOn, Vector2D viewingVector, Renderer<MapCell> renderer) throws SlickException {
-        int startCellX = (viewingVector.getX() / tileWidth);
-        int startCellY = (viewingVector.getY() / tileHeight);
+    public void render(Image imageToDrawOn, Vector2f viewingVector, Renderer<MapCell> renderer) throws SlickException {
+        int startCellX = (int)(viewingVector.getX() / tileWidth);
+        int startCellY = (int)(viewingVector.getY() / tileHeight);
 
         int endCellX = startCellX + cellsThatFitHorizontally;
         int endCellY = startCellY + cellsThatFitVertically;
 
         for (int x = startCellX; x <= endCellX; x++) {
             for (int y = startCellY; y <= endCellY; y++) {
-                int drawX = ((x - startCellX) * tileWidth) - (viewingVector.getX() % tileWidth);
-                int drawY = ((y - startCellY) * tileHeight) - (viewingVector.getY() % tileHeight);
+                int drawX = ((x - startCellX) * tileWidth) - ((int)viewingVector.getX() % tileWidth);
+                int drawY = ((y - startCellY) * tileHeight) - ((int)viewingVector.getY() % tileHeight);
 
                 renderer.draw(imageToDrawOn.getGraphics(), new MapCell(map, x, y), drawX, drawY);
             }

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureRenderer.java
@@ -7,40 +7,16 @@ import org.newdawn.slick.Image;
 
 public class StructureRenderer implements Renderer<Structure> {
 
-    private float selectedIntensity;
-    private boolean selectedDarkening;
-    private final float intensityChange;
-
-    public StructureRenderer() {
-        selectedIntensity = 1.0f;
-        selectedDarkening = true;
-        intensityChange = 0.5f / 60; // TODO: make time based
-    }
-
     @Override
     public void draw(Graphics graphics, Structure structure, int drawX, int drawY) {
         Image sprite = structure.getSprite();
         graphics.drawImage(sprite, drawX, drawY);
 
         if (structure.isSelected()) {
-            graphics.setColor(new Color(selectedIntensity, selectedIntensity, selectedIntensity));
+            float intensity = structure.getSelectedIntensity();
+            graphics.setColor(new Color(intensity, intensity, intensity));
             graphics.setLineWidth(2.f);
             graphics.drawRect(drawX, drawY, structure.getWidth() - 1, structure.getHeight() - 1);
-
-            if (selectedDarkening) {
-                selectedIntensity -= intensityChange;
-            } else {
-                selectedIntensity += intensityChange;
-            }
-
-            // fade back and forth
-            if (selectedIntensity <= 0.0f) {
-                selectedIntensity = 0.0f;
-                selectedDarkening = false;
-            } else if (selectedIntensity >= 1.0f) {
-                selectedIntensity = 1.0f;
-                selectedDarkening = true;
-            }
         }
     }
 

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureViewportRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureViewportRenderer.java
@@ -3,11 +3,11 @@ package com.fundynamic.d2tm.game.map.renderer;
 
 import com.fundynamic.d2tm.game.map.Cell;
 import com.fundynamic.d2tm.game.map.Map;
-import com.fundynamic.d2tm.game.map.MapCell;
 import com.fundynamic.d2tm.game.math.Vector2D;
 import com.fundynamic.d2tm.game.structures.Structure;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
+import org.newdawn.slick.geom.Vector2f;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -29,9 +29,9 @@ public class StructureViewportRenderer implements ViewportRenderer<Structure> {
     }
 
     @Override
-    public void render(Image imageToDrawOn, Vector2D viewingVector, Renderer<Structure> renderer) throws SlickException {
-        int startCellX = (viewingVector.getX() / tileWidth);
-        int startCellY = (viewingVector.getY() / tileHeight);
+    public void render(Image imageToDrawOn, Vector2f viewingVector, Renderer<Structure> renderer) throws SlickException {
+        int startCellX = (int)(viewingVector.getX() / tileWidth);
+        int startCellY = (int)(viewingVector.getY() / tileHeight);
 
         int endCellX = startCellX + cellsThatFitHorizontally;
         int endCellY = startCellY + cellsThatFitVertically;
@@ -44,8 +44,8 @@ public class StructureViewportRenderer implements ViewportRenderer<Structure> {
 
                 Vector2D mapCoordinates = cell.getStructure().getMapCoordinates();
 
-                int drawX = ((mapCoordinates.getX() - startCellX) * tileWidth) - (viewingVector.getX() % tileWidth);
-                int drawY = ((mapCoordinates.getY() - startCellY) * tileHeight) - (viewingVector.getY() % tileHeight);
+                int drawX = ((mapCoordinates.getX() - startCellX) * tileWidth) - ((int)viewingVector.getX() % tileWidth);
+                int drawY = ((mapCoordinates.getY() - startCellY) * tileHeight) - ((int)viewingVector.getY() % tileHeight);
 
                 structuresToDraw.add(new StructureToDraw(cell.getStructure(), drawX, drawY));
             }

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureViewportRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureViewportRenderer.java
@@ -24,14 +24,14 @@ public class StructureViewportRenderer implements ViewportRenderer<Structure> {
         this.map = map;
         this.tileHeight = tileHeight;
         this.tileWidth = tileWidth;
-        cellsThatFitHorizontally = (windowDimensions.getX() / tileWidth) + 1;
-        cellsThatFitVertically = (windowDimensions.getY() / tileHeight) + 1;
+        cellsThatFitHorizontally = (windowDimensions.getXAsInt() / tileWidth) + 1;
+        cellsThatFitVertically = (windowDimensions.getYAsInt() / tileHeight) + 1;
     }
 
     @Override
-    public void render(Image imageToDrawOn, Vector2f viewingVector, Renderer<Structure> renderer) throws SlickException {
-        int startCellX = (int)(viewingVector.getX() / tileWidth);
-        int startCellY = (int)(viewingVector.getY() / tileHeight);
+    public void render(Image imageToDrawOn, Vector2D viewingVector, Renderer<Structure> renderer) throws SlickException {
+        int startCellX = viewingVector.getXAsInt() / tileWidth;
+        int startCellY = viewingVector.getYAsInt() / tileHeight;
 
         int endCellX = startCellX + cellsThatFitHorizontally;
         int endCellY = startCellY + cellsThatFitVertically;
@@ -44,8 +44,8 @@ public class StructureViewportRenderer implements ViewportRenderer<Structure> {
 
                 Vector2D mapCoordinates = cell.getStructure().getMapCoordinates();
 
-                int drawX = ((mapCoordinates.getX() - startCellX) * tileWidth) - ((int)viewingVector.getX() % tileWidth);
-                int drawY = ((mapCoordinates.getY() - startCellY) * tileHeight) - ((int)viewingVector.getY() % tileHeight);
+                int drawX = ((mapCoordinates.getXAsInt() - startCellX) * tileWidth) - (viewingVector.getXAsInt() % tileWidth);
+                int drawY = ((mapCoordinates.getYAsInt() - startCellY) * tileHeight) - (viewingVector.getYAsInt() % tileHeight);
 
                 structuresToDraw.add(new StructureToDraw(cell.getStructure(), drawX, drawY));
             }

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureViewportRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/StructureViewportRenderer.java
@@ -7,7 +7,6 @@ import com.fundynamic.d2tm.game.math.Vector2D;
 import com.fundynamic.d2tm.game.structures.Structure;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
-import org.newdawn.slick.geom.Vector2f;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/ViewportRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/ViewportRenderer.java
@@ -1,9 +1,8 @@
 package com.fundynamic.d2tm.game.map.renderer;
 
-
-import com.fundynamic.d2tm.game.math.Vector2D;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
+import org.newdawn.slick.geom.Vector2f;
 
 /**
  * <p>
@@ -21,6 +20,6 @@ import org.newdawn.slick.SlickException;
  */
 public interface ViewportRenderer<T> {
 
-    public void render(Image imageToDrawOn, Vector2D viewingVector, Renderer<T> renderer) throws SlickException;
+    public void render(Image imageToDrawOn, Vector2f viewingVector, Renderer<T> renderer) throws SlickException;
 
 }

--- a/src/main/java/com/fundynamic/d2tm/game/map/renderer/ViewportRenderer.java
+++ b/src/main/java/com/fundynamic/d2tm/game/map/renderer/ViewportRenderer.java
@@ -1,8 +1,8 @@
 package com.fundynamic.d2tm.game.map.renderer;
 
+import com.fundynamic.d2tm.game.math.Vector2D;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
-import org.newdawn.slick.geom.Vector2f;
 
 /**
  * <p>
@@ -20,6 +20,6 @@ import org.newdawn.slick.geom.Vector2f;
  */
 public interface ViewportRenderer<T> {
 
-    public void render(Image imageToDrawOn, Vector2f viewingVector, Renderer<T> renderer) throws SlickException;
+    public void render(Image imageToDrawOn, Vector2D viewingVector, Renderer<T> renderer) throws SlickException;
 
 }

--- a/src/main/java/com/fundynamic/d2tm/game/math/Vector2D.java
+++ b/src/main/java/com/fundynamic/d2tm/game/math/Vector2D.java
@@ -18,12 +18,12 @@ public class Vector2D {
         this.vec = new Vector2f(x, y);
     }
 
-    public int getX() {
-        return (int) vec.getX();
+    public float getX() {
+        return vec.getX();
     }
 
-    public int getY() {
-        return (int) vec.getY();
+    public float getY() {
+        return vec.getY();
     }
 
     public Vector2D move(Vector2D velocity) {
@@ -36,9 +36,6 @@ public class Vector2D {
         return new Vector2D(newX, newY);
     }
 
-    public String shortString() {
-        return "{" + vec.getX() + ", " + vec.getX() + "}";
-    }
     @Override
     public String toString() {
         return "Vector2D{" +
@@ -57,5 +54,15 @@ public class Vector2D {
 
     public int getYAsInt() {
         return (int) vec.getY();
+    }
+
+    public Vector2D scale(float delta) {
+        Vector2f scaled = vec.copy().scale(delta);
+        return Vector2D.create(scaled.getX(), scaled.getY());
+    }
+
+    public Vector2D add(Vector2D other) {
+        Vector2f added = vec.copy().add(other.vec);
+        return Vector2D.create(added.getX(), added.getY());
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/math/Vector2D.java
+++ b/src/main/java/com/fundynamic/d2tm/game/math/Vector2D.java
@@ -65,4 +65,21 @@ public class Vector2D {
         Vector2f added = vec.copy().add(other.vec);
         return Vector2D.create(added.getX(), added.getY());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Vector2D vector2D = (Vector2D) o;
+
+        if (vec != null ? !vec.equals(vector2D.vec) : vector2D.vec != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return vec != null ? vec.hashCode() : 0;
+    }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -6,6 +6,7 @@ import com.fundynamic.d2tm.game.event.QuitGameKeyListener;
 import com.fundynamic.d2tm.game.event.ViewportMovementListener;
 import com.fundynamic.d2tm.game.map.Map;
 import com.fundynamic.d2tm.game.math.Vector2D;
+import com.fundynamic.d2tm.game.structures.Structure;
 import com.fundynamic.d2tm.game.structures.StructuresRepository;
 import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.graphics.Shroud;
@@ -89,11 +90,13 @@ public class PlayingState extends BasicGameState {
 
     @Override
     public void update(GameContainer container, StateBasedGame game, int delta) throws SlickException {
-        float deltaMs = delta / 1000f;
+        float deltaInSeconds = delta / 1000f;
+
+        for (Structure structure : map.getStructures()) {
+          structure.update(deltaInSeconds);
+        }
         for (Viewport viewport : viewports) {
-            viewport.update(deltaMs);
+            viewport.update(deltaInSeconds);
         }
     }
-
-    // The amount of time thats passed in millisecond since last update
 }

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -13,7 +13,6 @@ import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Input;
 import org.newdawn.slick.SlickException;
-import org.newdawn.slick.geom.Vector2f;
 import org.newdawn.slick.state.BasicGameState;
 import org.newdawn.slick.state.StateBasedGame;
 

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -69,7 +69,7 @@ public class PlayingState extends BasicGameState {
         try {
             float moveSpeed = 30 * tileWidth;
             Vector2D viewportDrawingPosition = Vector2D.zero();
-            Vector2f viewingVector = new Vector2f(40, 40);
+            Vector2D viewingVector = Vector2D.create(40, 40);
             Viewport viewport = new Viewport(screenResolution, viewportDrawingPosition, viewingVector, graphics, this.map, moveSpeed, tileWidth, tileHeight, mouse);
 
             // Add listener for this viewport
@@ -95,4 +95,6 @@ public class PlayingState extends BasicGameState {
             viewport.update(deltaMs);
         }
     }
+
+    // The amount of time thats passed in millisecond since last update
 }

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -9,7 +9,11 @@ import com.fundynamic.d2tm.game.math.Vector2D;
 import com.fundynamic.d2tm.game.structures.StructuresRepository;
 import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.graphics.Shroud;
-import org.newdawn.slick.*;
+import org.newdawn.slick.GameContainer;
+import org.newdawn.slick.Graphics;
+import org.newdawn.slick.Input;
+import org.newdawn.slick.SlickException;
+import org.newdawn.slick.geom.Vector2f;
 import org.newdawn.slick.state.BasicGameState;
 import org.newdawn.slick.state.StateBasedGame;
 
@@ -63,9 +67,9 @@ public class PlayingState extends BasicGameState {
         this.structuresRepository.placeStructureOnMap(Vector2D.create(5, 5), StructuresRepository.REFINERY);
 
         try {
-            float moveSpeed = 16.0F;
+            float moveSpeed = 30 * tileWidth;
             Vector2D viewportDrawingPosition = Vector2D.zero();
-            Vector2D viewingVector = Vector2D.create(40, 40);
+            Vector2f viewingVector = new Vector2f(40, 40);
             Viewport viewport = new Viewport(screenResolution, viewportDrawingPosition, viewingVector, graphics, this.map, moveSpeed, tileWidth, tileHeight, mouse);
 
             // Add listener for this viewport
@@ -86,8 +90,9 @@ public class PlayingState extends BasicGameState {
 
     @Override
     public void update(GameContainer container, StateBasedGame game, int delta) throws SlickException {
+        float deltaMs = delta / 1000f;
         for (Viewport viewport : viewports) {
-            viewport.update();
+            viewport.update(deltaMs);
         }
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/state/PlayingState.java
@@ -60,7 +60,7 @@ public class PlayingState extends BasicGameState {
         input.addKeyListener(new QuitGameKeyListener(gameContainer));
 
         this.map = Map.generateRandom(terrainFactory, shroud, 64, 64);
-        this.structuresRepository = new StructuresRepository(map, tileWidth, tileHeight);
+        this.structuresRepository = new StructuresRepository(map);
 
         this.mouse = new Mouse();
 

--- a/src/main/java/com/fundynamic/d2tm/game/structures/Structure.java
+++ b/src/main/java/com/fundynamic/d2tm/game/structures/Structure.java
@@ -1,6 +1,5 @@
 package com.fundynamic.d2tm.game.structures;
 
-import com.fundynamic.d2tm.game.math.Random;
 import com.fundynamic.d2tm.game.math.Vector2D;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SpriteSheet;
@@ -12,6 +11,12 @@ public class Structure {
     private final int width;
     private final int height;
     private boolean selected;
+    private float selectedIntensity;
+    private boolean selectedDarkening;
+    private float animationTimer;
+
+    private static final int ANIMATION_FRAME_COUNT = 2;
+    private static final int ANIMATION_FRAMES_PER_SECOND = 5;
 
     public Structure(Vector2D mapCoordinates, Image imageOfStructure, int width, int height) {
         this(mapCoordinates, new SpriteSheet(imageOfStructure, width, height), width, height);
@@ -23,6 +28,8 @@ public class Structure {
         this.spriteSheet = spriteSheet;
         this.mapCoordinates = mapCoordinates;
         this.selected = false;
+        this.selectedIntensity = 1f;
+        this.selectedDarkening = true;
     }
 
     public SpriteSheet getSpriteSheet() {
@@ -31,7 +38,35 @@ public class Structure {
 
     public Image getSprite() {
         // TODO: remove randomization here when we get a proper 'waving flag animation' done
-        return getSpriteSheet().getSprite(0, Random.getRandomBetween(0, 2));
+        int animationFrame = (int)animationTimer;
+        return getSpriteSheet().getSprite(0, animationFrame);
+    }
+
+    public void update(float delta) {
+        // REVIEW: maybe base the animation on a global timer, so all animations are in-sync?
+        float offset = delta * ANIMATION_FRAMES_PER_SECOND;
+        animationTimer = (animationTimer + offset) % ANIMATION_FRAME_COUNT;
+
+        if (isSelected()) {
+            float intensityChange = .5f * delta;
+            if (selectedDarkening) {
+                selectedIntensity -= intensityChange;
+            } else {
+                selectedIntensity += intensityChange;
+            }
+
+            // fade back and forth
+            if (selectedIntensity <= 0.0f) {
+                selectedIntensity = 0.0f;
+                selectedDarkening = false;
+            } else if (selectedIntensity >= 1.0f) {
+                selectedIntensity = 1.0f;
+                selectedDarkening = true;
+            }
+        } else {
+            selectedIntensity = 1f;
+            selectedDarkening = true;
+        }
     }
 
     public int getWidth() {
@@ -57,4 +92,6 @@ public class Structure {
     public boolean isSelected() {
         return selected;
     }
+
+    public float getSelectedIntensity() { return selectedIntensity; }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/structures/StructuresRepository.java
+++ b/src/main/java/com/fundynamic/d2tm/game/structures/StructuresRepository.java
@@ -41,14 +41,14 @@ public class StructuresRepository {
         StructureData data = structureData[type];
         Structure structure = new Structure(topLeft, data.image, data.width, data.height);
 
-        map.getCell(topLeft.getX(), topLeft.getY()).setStructure(structure).setTopLeftOfStructure(true);
+        map.getCell(topLeft.getXAsInt(), topLeft.getYAsInt()).setStructure(structure).setTopLeftOfStructure(true);
 
         int widthInCells = data.width / tileWidth;
         int heightInCells = data.height / tileHeight;
 
         for (int x = 0; x < widthInCells; x++) {
             for (int y = 0; y < heightInCells; y++) {
-                map.getCell(topLeft.getX() + x, topLeft.getY() + y).setStructure(structure);
+                map.getCell(topLeft.getXAsInt() + x, topLeft.getYAsInt() + y).setStructure(structure);
             }
         }
     }

--- a/src/main/java/com/fundynamic/d2tm/game/structures/StructuresRepository.java
+++ b/src/main/java/com/fundynamic/d2tm/game/structures/StructuresRepository.java
@@ -16,14 +16,10 @@ public class StructuresRepository {
     private final Map map;
 
     private StructureData structureData[] = new StructureData[MAX_TYPES];
-    private final int tileWidth;
-    private final int tileHeight;
 
-    public StructuresRepository(Map map, int tileWidth, int tileHeight) throws SlickException {
+    public StructuresRepository(Map map) throws SlickException {
         // TODO: read this data from an external (XML/JSON/YML/INI) file
         this.map = map;
-        this.tileWidth = tileWidth;
-        this.tileHeight = tileHeight;
         StructureData constructionYard = new StructureData();
         structureData[CONSTRUCTION_YARD] = constructionYard;
         constructionYard.image = new Image("structures/2x2_constyard.png");
@@ -40,22 +36,12 @@ public class StructuresRepository {
     public void placeStructureOnMap(Vector2D topLeft, int type) {
         StructureData data = structureData[type];
         Structure structure = new Structure(topLeft, data.image, data.width, data.height);
-
-        map.getCell(topLeft.getXAsInt(), topLeft.getYAsInt()).setStructure(structure).setTopLeftOfStructure(true);
-
-        int widthInCells = data.width / tileWidth;
-        int heightInCells = data.height / tileHeight;
-
-        for (int x = 0; x < widthInCells; x++) {
-            for (int y = 0; y < heightInCells; y++) {
-                map.getCell(topLeft.getXAsInt() + x, topLeft.getYAsInt() + y).setStructure(structure);
-            }
-        }
+        map.placeStructure(topLeft, structure, data);
     }
 
-    class StructureData {
-        Image image;
-        int width;
-        int height;
+    public class StructureData {
+        public Image image;
+        public int width;
+        public int height;
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/structures/StructuresRepository.java
+++ b/src/main/java/com/fundynamic/d2tm/game/structures/StructuresRepository.java
@@ -36,7 +36,7 @@ public class StructuresRepository {
     public void placeStructureOnMap(Vector2D topLeft, int type) {
         StructureData data = structureData[type];
         Structure structure = new Structure(topLeft, data.image, data.width, data.height);
-        map.placeStructure(topLeft, structure, data);
+        map.placeStructure(structure, data);
     }
 
     public class StructureData {

--- a/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
@@ -2,7 +2,6 @@ package com.fundynamic.d2tm.game.event;
 
 import com.fundynamic.d2tm.game.controls.Mouse;
 import com.fundynamic.d2tm.game.drawing.Viewport;
-import com.fundynamic.d2tm.game.map.Cell;
 import com.fundynamic.d2tm.game.map.Map;
 import com.fundynamic.d2tm.game.map.MapCell;
 import com.fundynamic.d2tm.game.math.Vector2D;
@@ -11,7 +10,6 @@ import com.fundynamic.d2tm.game.structures.StructuresRepository;
 import com.fundynamic.d2tm.game.terrain.Terrain;
 import com.fundynamic.d2tm.game.terrain.TerrainFactory;
 import com.fundynamic.d2tm.graphics.Shroud;
-import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,12 +20,12 @@ import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.Input;
 import org.newdawn.slick.SlickException;
+import org.newdawn.slick.geom.Vector2f;
 
 import static com.fundynamic.d2tm.game.AssertHelper.assertFloatEquals;
 import static com.fundynamic.d2tm.game.map.CellFactory.makeCell;
 import static junit.framework.Assert.assertSame;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -69,7 +67,7 @@ public class ViewportMovementListenerTest {
     }
 
     private Viewport makeDrawableViewPort(float viewportX, float viewportY, float moveSpeed) throws SlickException {
-        return new Viewport(screenResolution, Vector2D.zero(), new Vector2D(viewportX, viewportY), mock(Graphics.class), map, moveSpeed, TILE_WIDTH, TILE_HEIGHT, mouse) {
+        return new Viewport(screenResolution, Vector2D.zero(), new Vector2f(viewportX, viewportY), mock(Graphics.class), map, moveSpeed, TILE_WIDTH, TILE_HEIGHT, mouse) {
             // ugly seam in the code, but I'd rather do this than create a Spy
             @Override
             protected Image constructImage(Vector2D screenResolution) throws SlickException {
@@ -83,7 +81,7 @@ public class ViewportMovementListenerTest {
         // moved to 2 pixels close to the left of the screen
         listener.mouseMoved(3, ANY_COORDINATE_NOT_NEAR_BORDER, 2, ANY_COORDINATE_NOT_NEAR_BORDER);
 
-        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X - MOVE_SPEED, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y, viewportVector.getY());
@@ -94,7 +92,7 @@ public class ViewportMovementListenerTest {
         // moved to 2 pixels close to the right of the screen
         listener.mouseMoved(screenResolution.getX() - 3, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getX() - 2, ANY_COORDINATE_NOT_NEAR_BORDER);
 
-        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X + MOVE_SPEED, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y, viewportVector.getY());
@@ -105,7 +103,7 @@ public class ViewportMovementListenerTest {
         // moved to 2 pixels close to the top of the screen
         listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, 3, ANY_COORDINATE_NOT_NEAR_BORDER, 2);
 
-        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y - MOVE_SPEED, viewportVector.getY());
@@ -116,7 +114,7 @@ public class ViewportMovementListenerTest {
         // moved to 2 pixels close to the bottom of the screen
         listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getY() - 3, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getY() - 2);
 
-        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y + MOVE_SPEED, viewportVector.getY());
@@ -127,14 +125,14 @@ public class ViewportMovementListenerTest {
         // this updates viewport coordinates one move up and to the left
         listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER, 0, 0);
         updateAndRender(); // and move the viewport
-        Vector2D tickOneViewportVector = viewport.getViewingVector();
+        Vector2f tickOneViewportVector = viewport.getViewingVector();
 
         // move back to the middle
         listener.mouseMoved(0, 0, ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER);
         updateAndRender(); // and stop moving
 
         // Check that the viewport stopped moving
-        Vector2D viewportVector = getLastCalledViewport();
+        Vector2f viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved while expected to have stopped", tickOneViewportVector.getY(), viewportVector.getY());
         assertFloatEquals("X position moved while expected to have stopped", tickOneViewportVector.getX(), viewportVector.getX());
     }
@@ -144,14 +142,14 @@ public class ViewportMovementListenerTest {
         // this updates viewport coordinates one move up and to the left
         listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getX(), screenResolution.getY());
         updateAndRender(); // and move the viewport
-        Vector2D tickOneViewportVector = viewport.getViewingVector();
+        Vector2f tickOneViewportVector = viewport.getViewingVector();
 
         // move back to the middle
         listener.mouseMoved(screenResolution.getX(), screenResolution.getY(), ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER);
         updateAndRender(); // and stop moving
 
         // Check that the viewport stopped moving
-        Vector2D viewportVector = getLastCalledViewport();
+        Vector2f viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved while expected to have stopped", tickOneViewportVector.getY(), viewportVector.getY());
         assertFloatEquals("X position moved while expected to have stopped", tickOneViewportVector.getX(), viewportVector.getX());
     }
@@ -163,7 +161,7 @@ public class ViewportMovementListenerTest {
         updateAndRender();
         updateAndRender();
 
-        Vector2D viewportVector = getLastCalledViewport();
+        Vector2f viewportVector = getLastCalledViewport();
         assertFloatEquals("X position moved over the edge", 32F, viewportVector.getX());
     }
 
@@ -174,7 +172,7 @@ public class ViewportMovementListenerTest {
         updateAndRender();
         updateAndRender();
 
-        Vector2D viewportVector = getLastCalledViewport();
+        Vector2f viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved over the edge", 32F, viewportVector.getY());
     }
 
@@ -194,7 +192,7 @@ public class ViewportMovementListenerTest {
         updateAndRender();
         updateAndRender();
 
-        Vector2D viewportVector = getLastCalledViewport();
+        Vector2f viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved over the bottom", maxYViewportPosition, viewportVector.getY());
     }
 
@@ -212,7 +210,7 @@ public class ViewportMovementListenerTest {
         listener.mouseMoved(screenResolution.getX(), ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getX(), ANY_COORDINATE_NOT_NEAR_BORDER); // move right
         updateAndRender();
 
-        Vector2D viewportVector = getLastCalledViewport();
+        Vector2f viewportVector = getLastCalledViewport();
         assertFloatEquals("X position moved over the right", maxXViewportPosition, viewportVector.getX());
     }
 
@@ -243,17 +241,17 @@ public class ViewportMovementListenerTest {
         assertEquals(null, mouse.getLastSelectedStructure());
     }
 
-    private Vector2D updateAndRenderAndReturnNewViewportVector() throws SlickException {
+    private Vector2f updateAndRenderAndReturnNewViewportVector() throws SlickException {
         updateAndRender();
         return getLastCalledViewport();
     }
 
     private void updateAndRender() throws SlickException {
-        viewport.update();
+        viewport.update(1f);  // 1 frame per second
         viewport.render();
     }
 
-    private Vector2D getLastCalledViewport() throws SlickException {
+    private Vector2f getLastCalledViewport() throws SlickException {
         return viewport.getViewingVector();
     }
 

--- a/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/event/ViewportMovementListenerTest.java
@@ -20,7 +20,6 @@ import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.Input;
 import org.newdawn.slick.SlickException;
-import org.newdawn.slick.geom.Vector2f;
 
 import static com.fundynamic.d2tm.game.AssertHelper.assertFloatEquals;
 import static com.fundynamic.d2tm.game.map.CellFactory.makeCell;
@@ -38,6 +37,7 @@ public class ViewportMovementListenerTest {
     public static final int ANY_COORDINATE_NOT_NEAR_BORDER = 100;
     public static final float INITIAL_VIEWPORT_X = 34F;
     public static final float INITIAL_VIEWPORT_Y = 34F;
+    public static final float ONE_FRAME_PER_SECOND_DELTA = 1f;
 
     public static int HEIGHT_OF_MAP = 40;
     public static int WIDTH_OF_MAP = 46;
@@ -67,7 +67,7 @@ public class ViewportMovementListenerTest {
     }
 
     private Viewport makeDrawableViewPort(float viewportX, float viewportY, float moveSpeed) throws SlickException {
-        return new Viewport(screenResolution, Vector2D.zero(), new Vector2f(viewportX, viewportY), mock(Graphics.class), map, moveSpeed, TILE_WIDTH, TILE_HEIGHT, mouse) {
+        return new Viewport(screenResolution, Vector2D.zero(), Vector2D.create(viewportX, viewportY), mock(Graphics.class), map, moveSpeed, TILE_WIDTH, TILE_HEIGHT, mouse) {
             // ugly seam in the code, but I'd rather do this than create a Spy
             @Override
             protected Image constructImage(Vector2D screenResolution) throws SlickException {
@@ -81,7 +81,7 @@ public class ViewportMovementListenerTest {
         // moved to 2 pixels close to the left of the screen
         listener.mouseMoved(3, ANY_COORDINATE_NOT_NEAR_BORDER, 2, ANY_COORDINATE_NOT_NEAR_BORDER);
 
-        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X - MOVE_SPEED, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y, viewportVector.getY());
@@ -90,9 +90,9 @@ public class ViewportMovementListenerTest {
     @Test
     public void mouseHittingRightBorderOfScreenMovesViewportToRight() throws SlickException {
         // moved to 2 pixels close to the right of the screen
-        listener.mouseMoved(screenResolution.getX() - 3, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getX() - 2, ANY_COORDINATE_NOT_NEAR_BORDER);
+        listener.mouseMoved(screenResolution.getXAsInt() - 3, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getXAsInt() - 2, ANY_COORDINATE_NOT_NEAR_BORDER);
 
-        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X + MOVE_SPEED, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y, viewportVector.getY());
@@ -103,7 +103,7 @@ public class ViewportMovementListenerTest {
         // moved to 2 pixels close to the top of the screen
         listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, 3, ANY_COORDINATE_NOT_NEAR_BORDER, 2);
 
-        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y - MOVE_SPEED, viewportVector.getY());
@@ -112,9 +112,9 @@ public class ViewportMovementListenerTest {
     @Test
     public void mouseHittingBottomOfScreenMovesViewportDown() throws SlickException {
         // moved to 2 pixels close to the bottom of the screen
-        listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getY() - 3, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getY() - 2);
+        listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getYAsInt() - 3, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getYAsInt() - 2);
 
-        Vector2f viewportVector = updateAndRenderAndReturnNewViewportVector();
+        Vector2D viewportVector = updateAndRenderAndReturnNewViewportVector();
 
         assertFloatEquals(INITIAL_VIEWPORT_X, viewportVector.getX());
         assertFloatEquals(INITIAL_VIEWPORT_Y + MOVE_SPEED, viewportVector.getY());
@@ -125,14 +125,14 @@ public class ViewportMovementListenerTest {
         // this updates viewport coordinates one move up and to the left
         listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER, 0, 0);
         updateAndRender(); // and move the viewport
-        Vector2f tickOneViewportVector = viewport.getViewingVector();
+        Vector2D tickOneViewportVector = viewport.getViewingVector();
 
         // move back to the middle
         listener.mouseMoved(0, 0, ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER);
         updateAndRender(); // and stop moving
 
         // Check that the viewport stopped moving
-        Vector2f viewportVector = getLastCalledViewport();
+        Vector2D viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved while expected to have stopped", tickOneViewportVector.getY(), viewportVector.getY());
         assertFloatEquals("X position moved while expected to have stopped", tickOneViewportVector.getX(), viewportVector.getX());
     }
@@ -140,16 +140,16 @@ public class ViewportMovementListenerTest {
     @Test
     public void mouseFromBottomRightToNoBorderStopsMoving() throws SlickException {
         // this updates viewport coordinates one move up and to the left
-        listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getX(), screenResolution.getY());
+        listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getXAsInt(), screenResolution.getYAsInt());
         updateAndRender(); // and move the viewport
-        Vector2f tickOneViewportVector = viewport.getViewingVector();
+        Vector2D tickOneViewportVector = viewport.getViewingVector();
 
         // move back to the middle
-        listener.mouseMoved(screenResolution.getX(), screenResolution.getY(), ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER);
+        listener.mouseMoved(screenResolution.getXAsInt(), screenResolution.getYAsInt(), ANY_COORDINATE_NOT_NEAR_BORDER, ANY_COORDINATE_NOT_NEAR_BORDER);
         updateAndRender(); // and stop moving
 
         // Check that the viewport stopped moving
-        Vector2f viewportVector = getLastCalledViewport();
+        Vector2D viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved while expected to have stopped", tickOneViewportVector.getY(), viewportVector.getY());
         assertFloatEquals("X position moved while expected to have stopped", tickOneViewportVector.getX(), viewportVector.getX());
     }
@@ -161,7 +161,7 @@ public class ViewportMovementListenerTest {
         updateAndRender();
         updateAndRender();
 
-        Vector2f viewportVector = getLastCalledViewport();
+        Vector2D viewportVector = getLastCalledViewport();
         assertFloatEquals("X position moved over the edge", 32F, viewportVector.getX());
     }
 
@@ -172,7 +172,7 @@ public class ViewportMovementListenerTest {
         updateAndRender();
         updateAndRender();
 
-        Vector2f viewportVector = getLastCalledViewport();
+        Vector2D viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved over the edge", 32F, viewportVector.getY());
     }
 
@@ -187,12 +187,12 @@ public class ViewportMovementListenerTest {
         viewport = makeDrawableViewPort(viewportX, viewportY, moveSpeed);
         listener = new ViewportMovementListener(viewport, mouse, structuresRepository);
 
-        listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getY(), ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getY()); // move down
+        listener.mouseMoved(ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getYAsInt(), ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getYAsInt()); // move down
         updateAndRender();
         updateAndRender();
         updateAndRender();
 
-        Vector2f viewportVector = getLastCalledViewport();
+        Vector2D viewportVector = getLastCalledViewport();
         assertFloatEquals("Y position moved over the bottom", maxYViewportPosition, viewportVector.getY());
     }
 
@@ -207,10 +207,10 @@ public class ViewportMovementListenerTest {
         viewport = makeDrawableViewPort(viewportX, viewportY, moveSpeed);
         listener = new ViewportMovementListener(viewport, mouse, structuresRepository);
 
-        listener.mouseMoved(screenResolution.getX(), ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getX(), ANY_COORDINATE_NOT_NEAR_BORDER); // move right
+        listener.mouseMoved(screenResolution.getXAsInt(), ANY_COORDINATE_NOT_NEAR_BORDER, screenResolution.getXAsInt(), ANY_COORDINATE_NOT_NEAR_BORDER); // move right
         updateAndRender();
 
-        Vector2f viewportVector = getLastCalledViewport();
+        Vector2D viewportVector = getLastCalledViewport();
         assertFloatEquals("X position moved over the right", maxXViewportPosition, viewportVector.getX());
     }
 
@@ -241,17 +241,17 @@ public class ViewportMovementListenerTest {
         assertEquals(null, mouse.getLastSelectedStructure());
     }
 
-    private Vector2f updateAndRenderAndReturnNewViewportVector() throws SlickException {
+    private Vector2D updateAndRenderAndReturnNewViewportVector() throws SlickException {
         updateAndRender();
         return getLastCalledViewport();
     }
 
     private void updateAndRender() throws SlickException {
-        viewport.update(1f);  // 1 frame per second
+        viewport.update(ONE_FRAME_PER_SECOND_DELTA);
         viewport.render();
     }
 
-    private Vector2f getLastCalledViewport() throws SlickException {
+    private Vector2D getLastCalledViewport() throws SlickException {
         return viewport.getViewingVector();
     }
 

--- a/src/test/java/com/fundynamic/d2tm/game/map/PerimeterTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/map/PerimeterTest.java
@@ -1,7 +1,7 @@
 package com.fundynamic.d2tm.game.map;
 
-import com.fundynamic.d2tm.game.AssertHelper;
 import com.fundynamic.d2tm.game.math.Vector2D;
+import junit.framework.Assert;
 import org.junit.Test;
 
 public class PerimeterTest {
@@ -20,36 +20,31 @@ public class PerimeterTest {
     @Test
     public void correctsWhenGoingOverLeftEdge() {
         Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X - 0.1F, MIN_Y));
-        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
-        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+        Assert.assertEquals(Vector2D.create(MIN_X, MIN_Y), correctedVector);
     }
 
     @Test
     public void correctsWhenGoingOverRightEdge() {
         Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MAX_X + 0.1F, MIN_Y));
-        AssertHelper.assertFloatEquals(MAX_X, correctedVector.getX());
-        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+        Assert.assertEquals(Vector2D.create(MAX_X, MIN_Y), correctedVector);
     }
 
     @Test
     public void correctsWhenGoingUpperLeftEdge() {
         Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X, MIN_Y - 0.1F));
-        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
-        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+        Assert.assertEquals(Vector2D.create(MIN_X, MIN_Y), correctedVector);
     }
 
     @Test
     public void correctsWhenGoingBottomLeftEdge() {
         Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X, MAX_Y + 0.1F));
-        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
-        AssertHelper.assertFloatEquals(MAX_Y, correctedVector.getY());
+        Assert.assertEquals(Vector2D.create(MIN_X, MAX_Y), correctedVector);
     }
 
     @Test
     public void doesNothingWhenVectorIsWithinPerimiter() {
         Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X, MIN_Y));
-        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
-        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+        Assert.assertEquals(Vector2D.create(MIN_X, MIN_Y), correctedVector);
     }
 
 }

--- a/src/test/java/com/fundynamic/d2tm/game/map/PerimeterTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/map/PerimeterTest.java
@@ -1,0 +1,55 @@
+package com.fundynamic.d2tm.game.map;
+
+import com.fundynamic.d2tm.game.AssertHelper;
+import com.fundynamic.d2tm.game.math.Vector2D;
+import org.junit.Test;
+
+public class PerimeterTest {
+
+    public static final float MIN_X = 10;
+    public static final float MAX_X = 20;
+    public static final float MIN_Y = 10;
+    public static final float MAX_Y = 20;
+
+    private final Perimeter perimeter;
+
+    public PerimeterTest() {
+        perimeter = new Perimeter(MIN_X, MAX_X, MIN_Y, MAX_Y);
+    }
+
+    @Test
+    public void correctsWhenGoingOverLeftEdge() {
+        Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X - 0.1F, MIN_Y));
+        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
+        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+    }
+
+    @Test
+    public void correctsWhenGoingOverRightEdge() {
+        Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MAX_X + 0.1F, MIN_Y));
+        AssertHelper.assertFloatEquals(MAX_X, correctedVector.getX());
+        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+    }
+
+    @Test
+    public void correctsWhenGoingUpperLeftEdge() {
+        Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X, MIN_Y - 0.1F));
+        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
+        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+    }
+
+    @Test
+    public void correctsWhenGoingBottomLeftEdge() {
+        Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X, MAX_Y + 0.1F));
+        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
+        AssertHelper.assertFloatEquals(MAX_Y, correctedVector.getY());
+    }
+
+    @Test
+    public void doesNothingWhenVectorIsWithinPerimiter() {
+        Vector2D correctedVector = perimeter.makeSureVectorStaysWithin(Vector2D.create(MIN_X, MIN_Y));
+        AssertHelper.assertFloatEquals(MIN_X, correctedVector.getX());
+        AssertHelper.assertFloatEquals(MIN_Y, correctedVector.getY());
+    }
+
+}

--- a/src/test/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRendererTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRendererTest.java
@@ -11,7 +11,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
-import org.newdawn.slick.geom.Vector2f;
 
 import static org.mockito.Mockito.*;
 
@@ -34,7 +33,7 @@ public class MapCellViewportRendererTest {
 
         MapCellViewportRenderer mapCellViewportRenderer = new MapCellViewportRenderer(map, TILE_HEIGHT, TILE_WIDTH, new Vector2D(screenWidth, screenHeight));
 
-        Vector2f viewingVector = new Vector2f(0, 0);
+        Vector2D viewingVector = Vector2D.zero();
 
         Renderer renderer = mock(Renderer.class);
         mapCellViewportRenderer.render(mock(Image.class), viewingVector, renderer);

--- a/src/test/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRendererTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/map/renderer/MapCellViewportRendererTest.java
@@ -11,6 +11,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
+import org.newdawn.slick.geom.Vector2f;
 
 import static org.mockito.Mockito.*;
 
@@ -33,7 +34,7 @@ public class MapCellViewportRendererTest {
 
         MapCellViewportRenderer mapCellViewportRenderer = new MapCellViewportRenderer(map, TILE_HEIGHT, TILE_WIDTH, new Vector2D(screenWidth, screenHeight));
 
-        Vector2D viewingVector = Vector2D.zero();
+        Vector2f viewingVector = new Vector2f(0, 0);
 
         Renderer renderer = mock(Renderer.class);
         mapCellViewportRenderer.render(mock(Image.class), viewingVector, renderer);

--- a/src/test/java/com/fundynamic/d2tm/game/math/Vector2DTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/math/Vector2DTest.java
@@ -38,8 +38,8 @@ public class Vector2DTest {
     }
 
     @Test
-    public void movement() {
-        Vector2D org = Vector2D.create(10, 10);
+    public void equals() {
+        Assert.assertEquals(Vector2D.create(10, 10), Vector2D.create(10, 10));
     }
 
 }


### PR DESCRIPTION
Fixes #34 

To allow for subpixel movement I've switched from `Vector2D` to `Vector2f` for viewport movement. Structure animation isn't being handled yet.

I dislike `Vector2D` because it _sometimes_ loses precision - due to conversion from float to int - but the interface doesn't make clear when that happens. I think it should be converted to use integers only. If subpixel precision is necessary `Vector2f` should be used instead.

Speaking of `Vector2f`, I dislike that one as well because it's mutable :wink: When adding or scaling the vector it mutates the state of the current instance. This is counter-intuitive for me. For now I've fixed this by explicitly calling `.copy()` where necessary. I'd rather stear clear of mutating state and implement a non-mutable `Vector2f`. What do you think @stefanhendriks?